### PR TITLE
Bugfix: context menu in IDA >= 6.5

### DIFF
--- a/main.py
+++ b/main.py
@@ -129,9 +129,9 @@ def bind_ctx_menus():
             continue
 
         #Find Hex/IDA Views
-        if  'Hex View' in parent.windowTitle() or \
-            len(parent.windowTitle()) == 1 \
-        :
+        if ('Hex View' in parent.windowTitle() \
+                or 'IDA View' in parent.windowTitle() \
+                or len(parent.windowTitle()) == 1):
             hack.append(parent)
             menus.append(wid)
 


### PR DESCRIPTION
This enables the right-click context menu in IDA >= 6.5 (tested in IDA Demo 6.6).
